### PR TITLE
CASMPET-7080 add 'node-role.kubernetes.io/control-plane' to chart for k8s 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		$(NAME)
 
 package:

--- a/charts/cray-k8s-encryption/Chart.yaml
+++ b/charts/cray-k8s-encryption/Chart.yaml
@@ -34,5 +34,5 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
   artifacthub.io/license: MIT

--- a/charts/cray-k8s-encryption/Chart.yaml
+++ b/charts/cray-k8s-encryption/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-k8s-encryption
-version: 0.0.4
+version: 0.1.0
 description: Daemonset controlling k8s data rewrites relating to k8s encryption
 keywords:
   - api

--- a/charts/cray-k8s-encryption/files/node-encryption-annotation.sh
+++ b/charts/cray-k8s-encryption/files/node-encryption-annotation.sh
@@ -55,7 +55,7 @@ annotation_prefix() {
 # controlplane nodes have the encryption file so no sense in annotating anything
 # that isn't a control-plane.
 kubectl_get_controlplane_nodes() {
-  kubectl get nodes --selector=node-role.kubernetes.io/master --no-headers=true -o custom-columns=NAME:.metadata.name
+  kubectl get nodes --selector=node-role.kubernetes.io/control-plane --no-headers=true -o custom-columns=NAME:.metadata.name
 }
 
 # Used elsewhere but this determines which daemonset does work
@@ -66,7 +66,7 @@ first_controlplane_node() {
 # Wrapper for the crazy kubectl output to get taints and what nodes are ready.
 # Not sure taints are useful though as all shasta nodes have NoSchedule anyway.
 all_ready_controlplane_nodes() {
-  kubectl get nodes --selector=node-role.kubernetes.io/master -o jsonpath='{range .items[*]} {.metadata.name} {.status.conditions[?(@.type=="Ready")].status} {" "} {.spec.taints} {"\n"} {end}' | awk '/True/ {print $1}'
+  kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o jsonpath='{range .items[*]} {.metadata.name} {.status.conditions[?(@.type=="Ready")].status} {" "} {.spec.taints} {"\n"} {end}' | awk '/True/ {print $1}'
 }
 
 # We also want to refuse updates if any control plane node isn't Ready, so
@@ -131,7 +131,7 @@ encryption_config_annotation() {
 
 # Returns all the control plane annotation values, blank lines are "no annotation", that is OK
 get_controlplane_encryption_annotations() {
-  kubectl get nodes --selector=node-role.kubernetes.io/master -o jsonpath='{range .items[*]}{.metadata.annotations.'"$(annotation_prefix)"'}{"\n"}'
+  kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o jsonpath='{range .items[*]}{.metadata.annotations.'"$(annotation_prefix)"'}{"\n"}'
 }
 
 # Determines if/when it is ok to update secrets on first control-plane node

--- a/charts/cray-k8s-encryption/templates/daemonset.yaml
+++ b/charts/cray-k8s-encryption/templates/daemonset.yaml
@@ -32,10 +32,12 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: Exists
       tolerations:
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/cray-k8s-encryption/values.yaml
+++ b/charts/cray-k8s-encryption/values.yaml
@@ -44,7 +44,7 @@ environment:
 # - sed (also no gnu usage)
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-  tag: 1.21.12
+  tag: 1.24.17
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
## Summary and Scope

cray-k8s-encryption chart was updated for k8s 1.24 that will be in CSM 1.6. 

These changes include:
- using docker-kubectl image version 1.24.17
- adding 'node-role.kubernetes.io/control-plane' toleration
- changing node affinity to 'node-role.kubernetes.io/control-plane' from 'node-role.kubernetes.io/master' 

## Issues and Related PRs

* Resolves [CASMPET-7080](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7080)

## Testing

Upgraded this chart on Beau.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

